### PR TITLE
Update Node.js version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 as build
+FROM registry.access.redhat.com/ubi9/nodejs-18 as build
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The Dockerfile has been updated to use Node.js version 18 instead of version 20. This change might be due to specific version requirements or to address compatibility issues with other parts of the application.