### PR TITLE
Install @nestjs/cli in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY service/package*.json ./
 
 USER 0
 RUN npm ci --only=production
+RUN npm install @nestjs/cli
 USER 1001
 
 COPY service/ .


### PR DESCRIPTION
The Dockerfile has been updated to include the installation of @nestjs/cli. This package is required for building and managing NestJS applications.