### PR TITLE
Update user permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN npm install @nestjs/cli
 USER 1001
 
 COPY service/ .
-
+USER 0
 RUN npm run build
-
+USER 1001
 # Production stage
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
 


### PR DESCRIPTION
User permissions in the Dockerfile are updated. First, the user is changed to root to perform `npm run build`, and then switched back to the regular non-root user for the production stage. This enhances the security of the Docker image.