### PR TITLE
Load secrets from Vault in ConfigService

### DIFF
--- a/service/src/services/config.service.ts
+++ b/service/src/services/config.service.ts
@@ -69,6 +69,10 @@ export class ConfigService {
     [ConfigService.formKeys.SERVICE]: ConfigService.OPTIONS_SERVICE_BRANCHES,
   };
 
+  constructor( ) {
+    this.loadFromVault()
+  }
+
   async loadFromVault() {
     let token = process.env.VAULT_SECRET ?? ''
     const secretLocation = '/var/run/secrets/kubernetes.io/serviceaccount/token'


### PR DESCRIPTION
In the ConfigService, implemented a constructor to load secrets from Vault. Updated the configuration of multiple services to use variables fetched from the ConfigService instead of directly referencing environment variables, improving overall security and code manageability. Introduced a new VaultService for more logic separation.