### PR TITLE
Update token retrieval in ConfigService's loadFromVault method

### DIFF
--- a/service/src/services/config.service.ts
+++ b/service/src/services/config.service.ts
@@ -74,8 +74,9 @@ export class ConfigService {
   }
 
   async loadFromVault() {
-    let token = process.env.VAULT_SECRET ?? ''
+    console.log('Loading from vault')
     const secretLocation = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    let token = process.env.VAULT_SECRET ?? fs.readFileSync(secretLocation, 'utf8')
 
     if(fs.existsSync(secretLocation)) {
       const token = fs.readFileSync(secretLocation, 'utf8')
@@ -89,10 +90,9 @@ export class ConfigService {
       },
       body: JSON.stringify({
         role: process.env.VAULT_ROLE,
-        jwt: process.env.VAULT_SECRET ?? fs.readFileSync(secretLocation, 'utf8')
+        jwt: token
       })
     })
-
 
     const json = await content.json()
 


### PR DESCRIPTION
The method loadFromVault in ConfigService has been updated to read the token from a file if it exists in the given secret location. It will now also log a message when loading data from Vault. Furthermore, it uses this token for the jwt field in the request body, rather than re-reading it.