### PR TITLE
Refactor and improve token handling in ConfigService

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
 WORKDIR /usr/src/app
 
 COPY --from=build /usr/src/app/dist ./dist
+COPY --from=build /usr/src/app/src ./src
+COPY --from=build /usr/src/app/public ./public
 COPY --from=build /usr/src/app/node_modules ./node_modules
 
 ENV PORT=8080

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -11,7 +11,10 @@ import * as crypto from 'crypto';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpExceptionFilter } from './filters/http-exception.filter';
 import {ConfigService} from "./services";
+import {env} from "node:process";
 dotenv.config();
+
+
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);


### PR DESCRIPTION
The method loadFromVault in ConfigService has undergone an overhaul for better token management. The same previously-read token is now reused instead of being re-read for the jwt field of the request body. On top of that, it ensures token is read from file whenever it exists at the designated secret location. Lastly, a logging implementation has been added when the data is successfully loaded from Vault.