### PR TITLE
Simplify Dockerfile COPY commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,7 @@ FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
 
 WORKDIR /usr/src/app
 
-COPY --from=build /usr/src/app/dist ./dist
-COPY --from=build /usr/src/app/src ./src
-COPY --from=build /usr/src/app/public ./public
-COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/ .
 
 USER 0
 RUN chown -R 1001:0 /usr/src/app && chmod -R g=u /usr/src/app


### PR DESCRIPTION
The Dockerfile has been simplified by replacing multiple COPY commands with a single command, copying all contents from the build image. This change reduces the complexity as well as the number of lines in the Dockerfile, while retaining the same functionality.