### PR TITLE
Update Content Security Policy directives in main.ts

### DIFF
--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -45,31 +45,21 @@ async function bootstrap() {
       contentSecurityPolicy: {
         directives: {
           defaultSrc: [
-            "'self'",
-            'www.googletagmanager.com',
-            'https://www.googletagmanager.com',
+            "'self'"
           ],
           scriptSrc: [
             "'self'",
-            "'unsafe-inline'",
-            'www.googletagmanager.com',
-            'https://www.googletagmanager.com',
+            "'unsafe-inline'"
           ],
           styleSrc: [
             "'self'",
-            "'unsafe-inline'",
-            'www.googletagmanager.com',
-            'https://www.googletagmanager.com',
+            "'unsafe-inline'"
           ],
           imgSrc: [
             "'self'",
-            'https://www.google-analytics.com',
-            'https://region1.google-analytics.com',
           ],
           connectSrc: [
             "'self'",
-            'https://www.google-analytics.com',
-            'https://region1.google-analytics.com',
           ],
         },
       },


### PR DESCRIPTION
The updates include removing 'www.googletagmanager.com', 'https://www.googletagmanager.com', and Google Analytics references from the content security policy directives. This aims for a lighter security configuration and eliminates potential cross-site scripting risks. The 'defaultSrc', 'scriptSrc', 'styleSrc', 'imgSrc', and 'connectSrc' sections were affected.