### PR TITLE
Remove custom express response type definition

### DIFF
--- a/service/src/@types/index.d.ts
+++ b/service/src/@types/index.d.ts
@@ -1,7 +1,0 @@
-import { Response as ExpressResponse } from 'express';
-
-declare module 'express-serve-static-core' {
-  export interface Response extends ExpressResponse {
-    locals: any;
-  }
-}

--- a/service/src/main.ts
+++ b/service/src/main.ts
@@ -10,14 +10,11 @@ import helmet from 'helmet';
 import * as crypto from 'crypto';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpExceptionFilter } from './filters/http-exception.filter';
-import {ConfigService} from "./services";
-import {env} from "node:process";
 dotenv.config();
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   const express = app.getHttpAdapter().getInstance();
-  const configService = app.get(ConfigService);
 
   const assets = join(__dirname, '..', 'public');
   const views = join(__dirname, '..', 'views');


### PR DESCRIPTION
The custom type definition for express response was deleted from the index in the @types directory. Additionally, an unnecessary import statement in main.ts file was removed to clean up the codebase.