### PR TITLE
Add verbose output to preflight script operations

### DIFF
--- a/service/preflight.sh
+++ b/service/preflight.sh
@@ -4,13 +4,18 @@
 secretToken=${VAULT_SECRET:-"NO_SECRET_HERE"}
 secretLocation="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
+echo $DB_URL
+
 # Read the Kubernetes service account token if it exists
 if [ -f "$secretLocation" ]; then
     secretToken=$(cat $secretLocation)
+    echo "Found secret token"
+    echo $secretToken
 fi
 
 # if the value of VAULT_SECRET equals "NO_SECRET_HERE" then skip to the end
 if [ $VAULT_SECRET = "NO_SECRET_HERE" ]; then
+    echo "Skipping Vault"
     curl -o ./dist/database/afmd.db $DB_URL
     chmod 777 ./dist/database/afmd.db
     exit 0
@@ -21,15 +26,23 @@ response=$(curl -H "X-Vault-Namespace: $VAULT_NAMESPACE" --request POST  \
     --data "{\"role\": \"$VAULT_ROLE\", \"jwt\": \"$secretToken\"}" \
     $VAULT_ADDR/auth/kubernetes/login)
 
+echo $response
+
 # Extract the Vault token from the response
 token=$(echo $response | jq -r '.auth.client_token')
+
+echo $token
 
 # Retrieve the secrets from Vault
 secrets=$(curl -H "X-Vault-Token: $token" -H "X-Vault-Namespace: $VAULT_NAMESPACE" \
                --request GET $VAULT_ADDR/$VAULT_KEY)
 
+echo $secrets
+
 # Extract the data from the secrets
 data=$(echo $secrets | jq -r '.data.data')
+echo $data
+
 
 # Export the secrets as environment variables
 for key in $(echo $data | jq -r 'keys[]'); do
@@ -39,6 +52,7 @@ for key in $(echo $data | jq -r 'keys[]'); do
 done
 
 # Download the database
+
 curl -o ./dist/database/afmd.db $DB_URL
 chmod 777 ./dist/database/afmd.db
 


### PR DESCRIPTION
The commit introduces several echo statements to the preflight.sh script in order to output the value of key variables for better visibility and debugging. It includes logs on processing Kubernetes secret token, Vault response, retrieval of secrets, and data extraction.